### PR TITLE
Feature add

### DIFF
--- a/profile-sync-daemon
+++ b/profile-sync-daemon
@@ -1,12 +1,12 @@
 #!/bin/bash
 # By graysky <graysky AT archlinux DOT us>
-# Inspired by some code originally  written by Colin Verot
+# Inspired by some code originally written by Colin Verot
 
 . /etc/psd.conf
 
 # nothing to do if there is no conf file
 if [ ! -f /etc/psd.conf ]; then
-	echo "Cannnot find /etc/psd.conf so bailing.  Reinstall package to use profile-sync-daemon."
+	echo "Cannnot find /etc/psd.conf so bailing. Reinstall package to use profile-sync-daemon."
 	exit 0
 else
 	. /etc/psd.conf
@@ -31,7 +31,7 @@ set_which() {
 	# reset global variables
 	STATIC=
 	LINK=
-    CRUFT=
+	CRUFT=
 
 	# skip homeless users
 	if [[ -z $homedir ]]; then
@@ -79,11 +79,11 @@ sync() {
 
 				# sync the RAM profile to the disc
 				if [[ -e $LINK/.flagged ]]; then
-                    su -c "rsync -a --delete --exclude .flagged --exclude '$CRUFT' '$LINK/' '$STATIC/'" $user
+				su -c "rsync -a --delete --exclude .flagged --exclude '$CRUFT' '$LINK/' '$STATIC/'" $user
 				else
 					su -c "rsync -a --exclude '$CRUFT' '$STATIC/' '$LINK/'" $user
 					su -c "touch '$LINK/.flagged'" $user
-                    ln -s "$STATIC/$CRUFT" "$LINK/$CRUFT"
+					ln -s "$STATIC/$CRUFT" "$LINK/$CRUFT"
 				fi
 			fi
 		done


### PR DESCRIPTION
First of all, thanks for building such a cool daemon.
So here is why I created this patch:.
In my netbook, the profile sync (firefox only) takes a long time, despite the browser's cache being small (maxed at 35Mb).
However, this file - urlclassifiers3.sqlite is huge at 55Mb after a VACUUM operation.
According to [this](http://forums.mozillazine.org/viewtopic.php?t=661382), this file is a database of malicious sites which is downloaded from google every time the browser is started.
This means that this huge file is not being used very often, thus it's use on a ramFS is limited. However it significantly increases the sync times during both startup and (especially) shutdown.

As for what it does:
If the browser is mozilla, then it adds an exception to the sync process - urlclassifiers3.sqlite.
This significantly reduces sync times and doesn't defeat the purpose of PSD.

Thank you for considering it.
I have tried to mimic your coding style to the extent of my (albeit somewhat limited) abilities in bash.
