### PR TITLE
cron fix

### DIFF
--- a/profile-sync-daemon
+++ b/profile-sync-daemon
@@ -141,6 +141,9 @@ case "$1" in
 		[[ ! -f $DAEMON_FILE ]] && check
 		sync
 		;;
+	resync)
+		[[ -f $DAEMON_FILE ]] && sync
+		;;
 	unsync)
 		# make sure the daemon is running
 		[[ -f $DAEMON_FILE ]] && sync && unsync

--- a/psd.cron.hourly
+++ b/psd.cron.hourly
@@ -1,2 +1,2 @@
 #!/bin/sh
-/usr/bin/profile-sync-daemon sync &> /dev/null
+/usr/bin/profile-sync-daemon resync >/dev/null 2>&1


### PR DESCRIPTION
If daemon is not started, cron will perform sync anyway. It is undesired and wrong at least because nobody will unsync our profiles on poweroff.
