### PR TITLE
Exclude empty process names when checking for running browsers

### DIFF
--- a/profile-sync-daemon
+++ b/profile-sync-daemon
@@ -116,7 +116,7 @@ refuse_to_start() {
 	for user in $USERS; do
 		for browser in $BROWSERS; do
 			set_which "$user" "$browser"
-			if [[ -n $(pgrep -u $user $PSNAME) ]]; then
+			if [[ -n $PSNAME ]] && pgrep -u "$user" "$PSNAME" &>/dev/null; then
 				echo "Refusing to start since $browser is running by $user"
 				echo "Exit this before starting the deamon to avoid data loss!"
 				exit 1


### PR DESCRIPTION
$PSNAME can currently be empty for the firefox and heftig-aurora browsers if
their profile folders do not exist. In this case, pgrep returns the PIDs of all
process assigned to the user, making psd think that a browser is running and
therefore psd refuses to start.
