### PR TITLE
Only try to kill running browsers when PSNAME is not empty

### DIFF
--- a/profile-sync-daemon
+++ b/profile-sync-daemon
@@ -133,8 +133,8 @@ kill_browsers() {
 
 			x=1
 			while [[ $x -le 5 ]]; do
-				if [[ -n $(pgrep -u $user $PSNAME) ]]; then
-					pkill -SIGTERM -u $user $PSNAME
+				if [[ -n "$PSNAME" ]] && pgrep -u "$user" "$PSNAME" &>/dev/null; then
+					pkill -SIGTERM -u "$user" "$PSNAME"
 				else
 					/bin/true
 				fi


### PR DESCRIPTION
Using an empty PSNAME in kill_browsers is even worse than the issue
fixed in commit 9a41021 as psd will kill all processes of the user.
