### PR TITLE
firefox-trunk support

### DIFF
--- a/common/profile-sync-daemon
+++ b/common/profile-sync-daemon
@@ -2,7 +2,7 @@
 # By graysky <graysky AT archlinux DOT us>
 # Inspired by some code originally  written by Colin Verot
 export BLD="\e[01m" RED="\e[01;31m" GRN="\e[01;32m" YLW="\e[01;33m" NRM="\e[00m"
-VERS="5.19"
+VERS="@VERSION@"
 
 PSDCONF=${PSDCONF:-"/etc/psd.conf"}
 


### PR DESCRIPTION
add support for firefox-trunk (Firefox Nightly from the ppa:ubuntu-mozilla-daily/ppa for Ubuntu -> more info @ http://www.webupd8.org/2011/05/install-firefox-nightly-from-ubuntu-ppa.html)
