### PR TITLE
add some verbose nonfatal error messages

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -461,6 +461,8 @@ do_sync() {
 						chown -h $user:$group "$DIR"
 						touch "$DIR/.flagged"
 					fi
+				else
+					echo -e "${RED}${DIR} does not exist or is a broken symlink! Is /home or ${VOLATILE} unmounted?${NRM}" >&2
 				fi
 			done
 		done
@@ -494,6 +496,8 @@ do_unsync() {
 					[[ -d "$BACKUP" ]] && mv "$BACKUP" "$DIR"
 					[[ -d "$VOLATILE/$user-$browser$suffix" ]] &&
 						rm -rf "$VOLATILE/$user-$browser$suffix"
+				else
+					echo -e "${RED}${DIR} does not exist or is not a symlink! Is /home unmounted?${NRM}" >&2
 				fi
 			done
 		done


### PR DESCRIPTION
Hitting those cases will not break the browser profile
(however he will probably lose all changes since last sync),
but indicate a problem with the user setup or service
shutdown process. This can happen e.g. when $VOLATILE gets unmounted
before the psd unsync in the shutdown process.
