### PR TITLE
Add support for chromium-dev (AUR package)

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -26,6 +26,7 @@ fi
 # all supported browsers
 ALL_BROWSERS=(
 	chromium
+	chromium-dev
 	conkeror.mozdev.org
 	firefox
 	firefox-trunk
@@ -73,6 +74,9 @@ dep_check() {
 	for browser in $(echo "$BROWSERS"); do
 		case "$browser" in
 			chromium)
+				return
+				;;
+			chromium-dev)
 				return
 				;;
 			conkeror.mozdev.org)
@@ -162,7 +166,7 @@ set_which() {
 			DIRArr[0]="$homedir/.$browser"
 			PSNAME="xulrunner"
 			;;
-		chromium|midori)
+		chromium|chromium-dev|midori)
 			DIRArr[0]="$homedir/.config/$browser"
 			PSNAME="$browser"
 			;;

--- a/common/psd.conf
+++ b/common/psd.conf
@@ -25,6 +25,7 @@ USERS=""
 #
 # Possible values:
 #  chromium
+#  chromium-dev
 #  conkeror.mozdev.org
 #  firefox
 #  firefox-trunk

--- a/doc/psd.1
+++ b/doc/psd.1
@@ -110,6 +110,8 @@ Currently, the following browsers are auto-detected and managed:
 .IP \(bu 3
 Chromium
 .IP \(bu 3
+Chromium-dev (Archlinux: chromium-dev package)
+.IP \(bu 3
 Conkeror
 .IP \(bu 3
 Firefox (stable,beta,aurora)


### PR DESCRIPTION
This is for adding support for the chromium-dev package in the AUR. By default, the profile location is `$XDG_CONFIG_HOME/chromium-dev`

I recently started using chromium-dev and noticed psd did not support it. I figured others who use chromium-dev may also like the ability to use psd with it.
