### PR TITLE
Added support for google-chrome-dev AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Profile-sync-daemon (psd) is a tiny pseudo-daemon designed to manage your browse
 * Firefox (stable,beta,aurora)
 * Firefox-trunk (this is an Ubuntu-only browser: http://www.webupd8.org/2011/05/install-firefox-nightly-from-ubuntu-ppa.html)
 * Heftig's version of Aurora (this is an Arch Linux-only browser: https://bbs.archlinux.org/viewtopic.php?id=117157)
-* Google Chrome (stable and beta)
+* Google Chrome (stable, beta and dev)
 * Luakit
 * Midori
 * Opera and Opera-Next

--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -32,6 +32,7 @@ ALL_BROWSERS=(
 	firefox-trunk
 	google-chrome
 	google-chrome-beta
+	google-chrome-unstable
 	heftig-aurora
 	midori
 	opera
@@ -92,6 +93,9 @@ dep_check() {
 				return
 				;;
 			google-chrome-beta)
+				return
+				;;
+			google-chrome-unstable)
 				return
 				;;
 			heftig-aurora)
@@ -170,7 +174,7 @@ set_which() {
 			DIRArr[0]="$homedir/.config/$browser"
 			PSNAME="$browser"
 			;;
-		google-chrome|google-chrome-beta)
+		google-chrome|google-chrome-beta|google-chrome-unstable)
 			DIRArr[0]="$homedir/.config/$browser"
 			PSNAME="chrome"
 			;;

--- a/doc/psd.1
+++ b/doc/psd.1
@@ -118,7 +118,7 @@ Firefox (stable,beta,aurora)
 .IP \(bu 3
 Firefox-trunk (this is an Ubuntu-only browser: http://www.webupd8.org/2011/05/install-firefox-nightly-from-ubuntu-ppa.html)
 .IP \(bu 3
-Google Chrome (stable and beta)
+Google Chrome (stable and beta and dev)
 .IP \(bu 3
 Heftig's version of Aurora (Arch Linux: https://bbs.archlinux.org/viewtopic.php?id=117157)
 .IP \(bu 3


### PR DESCRIPTION
This is for adding support for the google-chrome-dev package in the AUR. By default, the profile location is `$XDG_CONFIG_HOME/google-chrome-unstable`
