### PR TITLE
psd.conf: fix supported browser name

### DIFF
--- a/common/psd.conf
+++ b/common/psd.conf
@@ -31,7 +31,7 @@ USERS=""
 #  firefox-trunk
 #  google-chrome
 #  google-chrome-beta
-#  google-chrome-dev
+#  google-chrome-unstable
 #  heftig-aurora
 #  luakit
 #  midori


### PR DESCRIPTION
Minor fix in psd.conf. The google-chrome-dev actually stores its profile as google-chrome-unstable. This appears to be setup properly in the profile-sync-daemon.in file, but the supported value in psd.conf does not reflect it. 
