### PR TITLE
add to rsync --inplace, to cp --reflink=auto

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -446,7 +446,7 @@ ungraceful_state_check() {
 					[[ -h "$DIR" ]] && unlink "$DIR"
 					NOW=$(date +%Y%m%d_%H%M%S)
 					if [[ -d "$BACKUP" ]]; then
-						cp -a "$BACKUP" "$BACKUP-crashrecovery-$NOW"
+						cp -a --reflink=auto  "$BACKUP" "$BACKUP-crashrecovery-$NOW"
 						mv "$BACKUP" "$DIR"
 					fi
 				fi
@@ -484,11 +484,11 @@ do_sync() {
 
 					# sync the tmpfs targets to the disc
 					if [[ -e $DIR/.flagged ]]; then
-						rsync -aog --delete-after --delay-updates --exclude .flagged "$DIR/" "$BACKUP/"
+						rsync -aog --inplace --delete-after --delay-updates --exclude .flagged "$DIR/" "$BACKUP/"
 					else
 						# initial sync
 						# keep user from launching browser while rsync is active
-						rsync -aog --delay-updates "$BACKUP/" "$VOLATILE/$user-$browser$suffix/"
+						rsync -aog --inplace --delay-updates "$BACKUP/" "$VOLATILE/$user-$browser$suffix/"
 						ln -s "$VOLATILE/$user-$browser$suffix" "$DIR"
 						chown -h $user:$group "$DIR"
 						touch "$DIR/.flagged"


### PR DESCRIPTION
option --reflink=auto improve perfomance on CoW fs
for cp -a time=19s (ssd,btrfs,google-chrome=1.5G)
for cp -a --reflink=auto time=0.7s
rsync default time for start = 8s
rsync --inplace time for start = 1s
maybe i mistake in test, but this option safe to use and i think this can improve perfomance foroption --reflink=auto improve perfomance on CoW fs
for cp -a time=19s (ssd,btrfs,google-chrome=1.5G)
for cp -a --reflink=auto time=0.7s
rsync default time for start = 8s
rsync --inplace time for start = 1s
maybe i mistake in test, but this option safe to use and i think this can improve perfomance for psd
 psd
