### PR TITLE
[RFC improve performance for CoW]

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -446,7 +446,7 @@ ungraceful_state_check() {
 					[[ -h "$DIR" ]] && unlink "$DIR"
 					NOW=$(date +%Y%m%d_%H%M%S)
 					if [[ -d "$BACKUP" ]]; then
-						cp -a "$BACKUP" "$BACKUP-crashrecovery-$NOW"
+						cp -a --reflink=auto "$BACKUP" "$BACKUP-crashrecovery-$NOW"
 						mv "$BACKUP" "$DIR"
 					fi
 				fi
@@ -484,11 +484,11 @@ do_sync() {
 
 					# sync the tmpfs targets to the disc
 					if [[ -e $DIR/.flagged ]]; then
-						rsync -aog --delete-after --delay-updates --exclude .flagged "$DIR/" "$BACKUP/"
+						rsync -aog --delete-after --inplace --no-whole-file --exclude .flagged "$DIR/" "$BACKUP/"
 					else
 						# initial sync
 						# keep user from launching browser while rsync is active
-						rsync -aog --delay-updates "$BACKUP/" "$VOLATILE/$user-$browser$suffix/"
+						rsync -aog --inplace --no-whole-file "$BACKUP/" "$VOLATILE/$user-$browser$suffix/"
 						ln -s "$VOLATILE/$user-$browser$suffix" "$DIR"
 						chown -h $user:$group "$DIR"
 						touch "$DIR/.flagged"


### PR DESCRIPTION
I guided by http://goo.gl/tgqL8n
For rsync added --inplace, also added --no-whole-file,
--dalay-updates deleted (conflict with --inplace).
But i don't know how this affect for NoCoW fs.
To cp  added --reflink=auto - this reduce time to create failsafe recovery copy, safe on NoCoW
in my case dir=1.5G on ssd,btrfs
cp -a : 18s
cp -a --reflink=auto : 1.7s
