### PR TITLE
Preserve extended attributes while syncing

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -583,11 +583,11 @@ do_sync() {
 
 					# sync the tmpfs targets to the disc
 					if [[ -e "$DIR"/.flagged ]]; then
-						rsync -aog --delete-after --inplace --no-whole-file --exclude .flagged "$DIR/" "$BACKUP/"
+						rsync -aogX --delete-after --inplace --no-whole-file --exclude .flagged "$DIR/" "$BACKUP/"
 					else
 						# initial sync
 						# keep user from launching browser while rsync is active
-						rsync -aog --inplace --no-whole-file "$BACKUP/" "$VOLATILE/$user-$browser$suffix/"
+						rsync -aogX --inplace --no-whole-file "$BACKUP/" "$VOLATILE/$user-$browser$suffix/"
 						ln -s "$VOLATILE/$user-$browser$suffix" "$DIR"
 						chown -h $user:$group "$DIR"
 						touch "$DIR/.flagged"


### PR DESCRIPTION
From [downstream bug report](https://bugzilla.redhat.com/show_bug.cgi?id=1141523) I think it's needed to sync SELinux contexts.
