### PR TITLE
Move existing backup dir independent of recovery

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -260,13 +260,13 @@ ungraceful_state_check() {
 					return
 				else
 					[[ -h "$DIR" ]] && unlink "$DIR"
-					if [[ $CRRE -eq 1 ]]; then
-						# create a crashrecovery of profile
-						NOW=$(date +%Y%m%d_%H%M%S)
-						if [[ -d "$BACKUP" ]]; then
+					if [[ -d "$BACKUP" ]]; then
+						if [[ $CRRE -eq 1 ]]; then
+							# create a crashrecovery of profile
+							NOW=$(date +%Y%m%d_%H%M%S)
 							cp -a --reflink=auto "$BACKUP" "$BACKUP-crashrecovery-$NOW"
-							mv "$BACKUP" "$DIR"
 						fi
+						mv "$BACKUP" "$DIR"
 					fi
 				fi
 			done


### PR DESCRIPTION
Disabling backups in feature request #102 should allow a clean start after a ungraceful shutdown. This requires renaming the backup directory back to the original regardless of whether crash recovery is enabled.