### PR TITLE
add zsh completion

### DIFF
--- a/common/zsh-completion
+++ b/common/zsh-completion
@@ -1,0 +1,15 @@
+#compdef psd profile-sync-daemon
+
+_psd() {
+  local -a options
+
+  options=('preview:Parse config file (/run/psd.conf) to see which profiles will be managed'
+           'clean:Clean (delete without prompting) ALL crashrecovery dirs for all profiles'
+           'resync:Synchronize the tmpfs and media bound copy. Must be run as root user and NOT recommended.'
+           'sync:Force a manual sync. Must be run as root user and NOT recommended.'
+           'unsync:Force a manual unsync. Must be run as root user and NOT recommended.')
+
+  _describe 'options' options
+}
+
+_psd


### PR DESCRIPTION
Hi,

Not sure if you'd be interested in this PR, but here it is anyway.

Also, a patch for the `PKGBUILD` (not complete, as you'll have to update the checksums):

```
--- PKGBUILD.orig	2015-01-28 03:45:14.149489128 -0200
+++ PKGBUILD	2015-01-28 03:45:48.199429863 -0200
@@ -1,7 +1,7 @@
 # Maintainer: graysky <graysky AT archlinux DOT us>
 
 pkgname='profile-sync-daemon'
-pkgver=5.66
+pkgver=5.67
 pkgrel=1
 pkgdesc='Syncs browser profiles to tmpfs reducing SSD/HDD calls and speeding-up browsers.'
 arch=('any')
@@ -28,4 +28,5 @@
 	# the INSTALL document provided in the source tarball!
   make DESTDIR="$pkgdir" install-systemd-all
   install -Dm644 MIT "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 common/zsh-completion "$pkgdir/usr/share/zsh/site-functions/_psd"
 }
```

The effect (as you would expect) is like [this](https://clbin.com/KKiMXB.png) (PS. forget the extra space in the fourth line, I fixed it).