### PR TITLE
Add pycharm as a profile sync option

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -52,6 +52,7 @@ opera-beta
 opera-next
 otter-browser
 palemoon
+pycharm
 qupzilla
 rekonq
 seamonkey
@@ -216,6 +217,9 @@ config_check() {
 			palemoon)
 				return
 				;;
+			pycharm)
+				return
+				;;
 			vivaldi)
 				return
 				;;
@@ -355,6 +359,10 @@ set_which() {
 			;;
 		opera-developer|opera-beta)
 			DIRArr[0]="$homedir/.config/$browser"
+			PSNAME="$browser"
+			;;
+		pycharm)
+			DIRArr[0]="$homedir/.PyCharm40"
 			PSNAME="$browser"
 			;;
 		vivaldi)

--- a/common/psd.conf
+++ b/common/psd.conf
@@ -40,6 +40,7 @@ USERS=""
 #  otter-browser
 #  qupzilla
 #  palemoon
+#  pycharm
 #  rekonq
 #  seamonkey
 #  vivaldi


### PR DESCRIPTION
This pull request adds Idea Pycharm as a profile type.  Pycharm is a python IDE.  It saves a local history in its profile directory, along with indexes of the source code, and benefits (very) greatly from PSD.
