### PR TITLE
Reorder overlayfs detection so that it works with Ubuntu 15.04.

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -90,8 +90,8 @@ esac
 # the same filesystem, but not part of the same subtree.
 
 if [[ $OLFS -eq 1 ]]; then
-	[[ $(grep -ciF overlay /proc/filesystems) -eq 1 ]] && OLFSVER=23
-	[[ $(grep -ciF overlayfs /proc/filesystems) -eq 1 ]] && OLFSVER=22
+	[[ $(grep -ciE "overlayfs$" /proc/filesystems) -eq 1 ]] && OLFSVER=22
+	[[ $(grep -ciE "overlay$" /proc/filesystems) -eq 1 ]] && OLFSVER=23
 fi
 
 # get distro name


### PR DESCRIPTION
On Ubuntu 15.04, both `overlay` and `overlayfs` are present; however, with the current code, using `USE_OVERLAYFS="yes"` will cause `psd` to fail, since a upper, lower, and work directory is needed (which indicates this is equivalent to version 23).

I've changed the detection code so that:

1. It will check to see whether the line in `/proc/filesystems` is `overlay` or `overlayfs` (using regex).
2. `overlay` (version 23) is preferred over `overlayfs` (version 22).