### PR TITLE
Add man page for psd-overlay-helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,10 @@ install-man:
 	$(Q)echo -e '\033[1;32mInstalling manpage...\033[0m'
 	$(INSTALL_DIR) "$(DESTDIR)$(MANDIR)"
 	$(INSTALL_DATA) doc/psd.1 "$(DESTDIR)$(MANDIR)/psd.1"
+	$(INSTALL_DATA) doc/psd-overlay-helper.1 "$(DESTDIR)$(MANDIR)/psd-overlay-helper.1"
 ifneq ($(COMPRESS_MAN),0)
 	gzip -9 "$(DESTDIR)$(MANDIR)/psd.1"
+	gzip -9 "$(DESTDIR)$(MANDIR)/psd-overlay-helper.1"
 	ln -s psd.1.gz "$(DESTDIR)$(MANDIR)/$(PN).1.gz"
 else
 	ln -s psd.1 "$(DESTDIR)$(MANDIR)/$(PN).1"

--- a/doc/psd-overlay-helper.1
+++ b/doc/psd-overlay-helper.1
@@ -1,0 +1,17 @@
+.TH psd-overlay-helper 1 "13 June 2016" "" ""
+.SH NAME
+\fBpsd-overlay-helper \fP- Script to use overlay file system for profile-sync-daemon.
+\fB
+.SH DESCRIPTION
+Profile-sync-daemon (psd) is a tiny pseudo-daemon designed to manage browser profile/profiles in tmpfs and to periodically sync back to the physical disc (HDD/SSD). This is accomplished by an innovative use of rsync to maintain synchronization between a tmpfs copy and media-bound backup of the browser profile/profiles. Additionally, psd features several crash recovery features.
+
+The psd-overlay-helper script is used internally to enable the usage of the overlay file system. It should not be called by the user directly.
+.SH CONTRIBUTE
+Users wishing to contribute to this code, should fork and send a pull request. Source is freely available on the project page linked below.
+.SH ONLINE
+.IP \(bu 3
+Project page: https://github.com/graysky2/profile-sync-daemon
+.IP \(bu 3
+Wiki page: https://wiki.archlinux.org/index.php/Profile-sync-daemon
+.SH AUTHOR
+graysky (graysky AT archlinux DOT us)


### PR DESCRIPTION
Some distributions want to have a man page for all tools in /usr/[s]bin.
This commit adds a minimal version for psd-overlay-helper.