### PR TITLE
brave

### DIFF
--- a/common/browsers/brave
+++ b/common/browsers/brave
@@ -1,0 +1,2 @@
+DIRArr[0]="$homedir/.config/$browser"
+PSNAME="$browser"


### PR DESCRIPTION
adding support for the new Brave browser
Only thing is that the cache also is in the same folder.
doesn't matter to me, but maybe it will pain some but. you deside;)

also this ofc means that it also should be added as supported browser in psd.conf and readme.

have tested this locally on my  machine for a week with no problems.

first time doing this. don't know if this is the right way to propose changes. Please let me know.