### PR TITLE
Add support for waterfox

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ User of eCryptFS are encouraged not to use psd unless willing to help troublesho
 * Seamonkey
 * Surf (http://surf.suckless.org/)
 * Vivaldi-browser and Vivaldi-browser-snapshot
+* Waterfox (https://www.waterfoxproject.org/)
 
 ## Documentation
 Consult the man page or the wiki page: https://wiki.archlinux.org/index.php/Profile-sync-daemon

--- a/common/browsers/waterfox
+++ b/common/browsers/waterfox
@@ -1,0 +1,19 @@
+if [[ -d $HOME/.waterfox ]]; then
+    profileArr=( $(grep '[P,p]'ath= $HOME/.waterfox/profiles.ini | 
+    sed 's/[P,p]ath=//') )
+    index=0
+    PSNAME="$browser"
+    for profileItem in ${profileArr[@]}; do
+        if [[ $(echo $profileItem | cut -c1) = "/" ]]; then
+            # path is not relative
+            DIRArr[index]="$profileItem"
+        else
+            # we need to append the default path to give a
+            # fully qualified path
+            DIRArr[index]="$HOME/.waterfox/$profileItem"
+        fi
+        index=$index+1
+    done
+fi
+
+check_suffix=1

--- a/common/psd.conf
+++ b/common/psd.conf
@@ -46,6 +46,7 @@
 #  surf
 #  vivaldi
 #  vivaldi-snapshot
+# waterfox
 #
 #BROWSERS=""
 


### PR DESCRIPTION
Hi, this adds support for waterfox (https://www.waterfoxproject.org/), which has its profile in ~/.waterfox as of version 55. I tested it on my arch box and this works for me without issues.

Regards.