### PR TITLE
Fix BACKUP_LIMIT

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -88,7 +88,7 @@ fi
 if [[ -f "$PID_FILE" ]]; then
   if [[ -f "$PSDCONFDIR/.psd.conf" ]]; then
     PSDCONF="$PSDCONFDIR/.psd.conf"
-    unset USE_OVERLAYFS BROWSERS USE_BACKUPS
+    unset USE_OVERLAYFS BROWSERS USE_BACKUPS BACKUP_LIMIT
     . "$PSDCONF"
     # defining VOLATILE in the config is deprecated since v6.16
     VOLATILE="$XDG_RUNTIME_DIR"
@@ -635,6 +635,8 @@ parse() {
           echo -en " ${BLD}overlayfs size:"
           echo -e "$(tput cr)$(tput cuf 17) $rwsize${NRM}"
         fi
+        echo -en " ${BLD}backup limit:"
+        echo -e "$(tput cr)$(tput cuf 17) $BACKUP_LIMIT${NRM}"
         echo -en " ${BLD}recovery dirs:"
         if [[ "${#CRASHArr[@]}" -eq 0 ]]; then
           echo -e "$(tput cr)$(tput cuf 17) none${NRM}"


### PR DESCRIPTION
Currently BACKUP_LIMIT isn't being accounted for, as per [issue #214](https://github.com/graysky2/profile-sync-daemon/issues/214). This commit fixes that and adds relevant info to psd preview.