### PR TITLE
Allow spaces in profile folders of firefox

### DIFF
--- a/common/browsers/firefox
+++ b/common/browsers/firefox
@@ -1,9 +1,7 @@
 if [[ -d $HOME/.mozilla/firefox ]]; then
-    profileArr=( $(grep '[P,p]'ath= $HOME/.mozilla/firefox/profiles.ini |
-    sed 's/[P,p]ath=//') )
     index=0
     PSNAME="$browser"
-    for profileItem in ${profileArr[@]}; do
+    while read -r profileItem; do
         if [[ $(echo $profileItem | cut -c1) = "/" ]]; then
             # path is not relative
             DIRArr[index]="$profileItem"
@@ -13,7 +11,7 @@ if [[ -d $HOME/.mozilla/firefox ]]; then
             DIRArr[index]="$HOME/.mozilla/firefox/$profileItem"
         fi
         index=$index+1
-    done
+    done < <(grep '[P,p]'ath= $HOME/.mozilla/firefox/profiles.ini | sed 's/[P,p]ath=//')
 fi
 
 check_suffix=1

--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -392,7 +392,7 @@ dup_check() {
       # browser is on system so check profiles
       #
       # check that the LAST DIRECTORY in the full path is unique
-      unique_count=$(echo "${DIRArr[@]##*/}" | sed 's/ /\n/g' | sort -u | wc -l)
+      unique_count=$(printf "%s\n" "${DIRArr[@]##*/}" | sort -u | wc -l)
       # no problems so do nothing
       [[ ${#DIRArr[@]} -eq $unique_count ]] && continue
 


### PR DESCRIPTION
This fixes https://github.com/graysky2/profile-sync-daemon/issues/226. I successfully tested it (all other places seem to properly quote directory strings).

I'm still not fully satisfied with `common/browsers/firefox`. Maybe someone with more *bash* experience has an idea.

I didn't test any upgrade scripts though (and didn't use a version before).