### PR TITLE
Don't call "/bin/true" by absolute path

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -102,7 +102,7 @@ if [[ -z "$BACKUP_LIMIT" ]]; then
 else
   if [[ "$BACKUP_LIMIT" =~ ^[0-9]+$ ]]; then
     # correctly setup
-    /bin/true
+    true
   else
     echo -e " ${RED}ERROR:${NRM}${BLD} Bad value for BACKUP_LIMIT detected!${NRM}"
     exit 1


### PR DESCRIPTION
On NixOS, `/bin` is very sparsely populated, containing only `/bin/sh`. All other programs reside under `/nix/store` and are symlinked into the current profile on a as-needed basis.

The current version calls `/bin/true` by its absolute path, which hence fails on NixOS (with a warning message). With this commit, `true` is instead called without its path, therefore removing the warning message on NixOS. As a side effect, the script should run (nonmeasurably) faster, since `true` is a bash built-in while `/bin/true` is an external C program.