### PR TITLE
Add Brave Browser

### DIFF
--- a/common/browsers/brave
+++ b/common/browsers/brave
@@ -1,0 +1,2 @@
+DIRArr[0]="$XDG_CONFIG_HOME/BraveSoftware/Brave-Browser"
+PSNAME="$browser"

--- a/common/browsers/brave-beta
+++ b/common/browsers/brave-beta
@@ -1,0 +1,2 @@
+DIRArr[0]="$XDG_CONFIG_HOME/BraveSoftware/Brave-Browser-Beta"
+PSNAME="brave"

--- a/common/browsers/brave-dev
+++ b/common/browsers/brave-dev
@@ -1,0 +1,2 @@
+DIRArr[0]="$XDG_CONFIG_HOME/BraveSoftware/Brave-Browser-Dev"
+PSNAME="brave"

--- a/common/browsers/brave-nightly
+++ b/common/browsers/brave-nightly
@@ -1,0 +1,2 @@
+DIRArr[0]="$XDG_CONFIG_HOME/BraveSoftware/Brave-Browser-Nightly"
+PSNAME="brave"

--- a/common/psd.conf
+++ b/common/psd.conf
@@ -19,6 +19,9 @@
 # this variable is left commented.
 #
 # Possible values:
+#  brave
+#  brave-beta
+#  brave-dev
 #  chromium
 #  chromium-dev
 #  conkeror.mozdev.org

--- a/common/psd.conf
+++ b/common/psd.conf
@@ -22,6 +22,7 @@
 #  brave
 #  brave-beta
 #  brave-dev
+#  brave-nightly
 #  chromium
 #  chromium-dev
 #  conkeror.mozdev.org

--- a/doc/psd.1
+++ b/doc/psd.1
@@ -110,7 +110,7 @@ enable
 disable
 .SH SUPPORTED BROWSERS
 .IP \(bu 3
-Brave (stable, beta, and dev)
+Brave (stable, beta, dev and nightly)
 .IP \(bu 3
 Chromium (stable, beta, and dev)
 .IP \(bu 3

--- a/doc/psd.1
+++ b/doc/psd.1
@@ -110,6 +110,8 @@ enable
 disable
 .SH SUPPORTED BROWSERS
 .IP \(bu 3
+Brave (stable, beta, and dev)
+.IP \(bu 3
 Chromium (stable, beta, and dev)
 .IP \(bu 3
 Conkeror


### PR DESCRIPTION
Alternative to syncing each Brave version individually, we could also sync them all at once because they're all in $XDG_CONFIG_HOME/BraveSoftware and have the same process name.