### PR TITLE
implement suspend-sync

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -2,7 +2,7 @@ DEPENDENCIES
  bash >=4.0
  coreutils
  findutils
- glib2
+ glib2 (optional for suspend-sync support via gdbus)
  kmod
  rsync
  systemd

--- a/INSTALL
+++ b/INSTALL
@@ -2,6 +2,7 @@ DEPENDENCIES
  bash >=4.0
  coreutils
  findutils
+ glib2
  kmod
  rsync
  systemd

--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -186,6 +186,10 @@ dep_check() {
     echo -e " ${BLD}I require awk but it's not installed. ${RED}Aborting!${NRM}" >&2
     exit 1
   fi
+  if ! command -v gdbus >/dev/null 2>&1; then
+    echo -e " ${BLD}I require gdbus but it's not installed. ${RED}Aborting!${NRM}"
+    exit 1
+  fi
   if [[ $OLFS -eq 1 ]]; then
     [[ $OLFSVER -ge 22 ]] || {
       echo -e " ${BLD}Your kernel requires either the ${BLU}overlay${NRM}${BLD} or ${BLU}overlayfs${NRM}${BLD} module to use${NRM}"
@@ -604,6 +608,12 @@ parse() {
   else
     echo -e "${BLD} Overlayfs technology is currently ${RED}inactive${NRM}${BLD}.${NRM}"
   fi
+  psd_suspend_sync_state=$(pgrep -cf "psd-suspend-sync")
+  if [[ "$psd_suspend_sync_state" != 0 ]]; then
+    echo -e "${BLD} Sync on sleep protection is currently ${GRN}active${NRM}${BLD}.${NRM}"
+  else
+    echo -e "${BLD} Sync on sleep protection is currently ${RED}inactive${NRM}${BLD}.${NRM}"
+  fi
   echo
   echo -e "${BLD}Psd will manage the following per ${BLU}${PSDCONF}${NRM}${BLD}:${NRM}"
   echo
@@ -677,6 +687,22 @@ parse() {
   done
 }
 
+take_inhibit_lock() {
+  # ensure we only take one lock at a time
+  release_inhibit_lock
+  # background this to avoid hanging on startup
+  systemd-inhibit \
+    --mode="delay" \
+    --what="sleep" \
+    --who="profile-sync-daemon" \
+    --why="psd resync on suspend" \
+    /usr/bin/psd-suspend-sync &
+}
+
+release_inhibit_lock() {
+  [[ "$(pgrep -cf "psd-suspend-sync")" != 0 ]] && pkill -f psd-suspend-sync
+}
+
 case "$1" in
   p|P|Parse|parse|Preview|preview|debug)
     dep_check
@@ -695,14 +721,25 @@ case "$1" in
     ;;
   startup)
     # target for psd.service's ExecStart= for consistent error handling
+    # also handles taking initial inhibit-lock
     if [[ ! -f $PID_FILE ]]; then
       dep_check
       config_check
       dup_check
       running_check
       ungraceful_state_check
+      take_inhibit_lock
       echo -e "${BLD}psd startup check successful${NRM}"
     fi
+    ;;
+    suspend-sync)
+      # system preparing for sleep mode, resync when psd is active
+      psd_state=$(systemctl --user is-active psd)
+      [[ "$psd_state" = "active" ]] && do_sync
+      ;;
+  recycle-inhibit-lock)
+    # take inhibit lock for next suspend cycle
+    take_inhibit_lock
     ;;
   sync|resync)
     if [[ -f $PID_FILE ]]; then
@@ -722,6 +759,7 @@ case "$1" in
       do_sync
       kill_browsers
       do_unsync
+      release_inhibit_lock
     fi
     ;;
   *)

--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -90,7 +90,7 @@ fi
 if [[ -f "$PID_FILE" ]]; then
   if [[ -f "$PSDCONFDIR/.psd.conf" ]]; then
     PSDCONF="$PSDCONFDIR/.psd.conf"
-    unset USE_OVERLAYFS BROWSERS USE_BACKUPS BACKUP_LIMIT
+    unset USE_OVERLAYFS USE_SUSPSYNC BROWSERS USE_BACKUPS BACKUP_LIMIT
     . "$PSDCONF"
     # defining VOLATILE in the config is deprecated since v6.16
     VOLATILE="$XDG_RUNTIME_DIR"
@@ -127,6 +127,16 @@ case "${USE_OVERLAYFS,,}" in
     ;;
   *)
     OLFS=0
+    ;;
+esac
+
+# simple function to determine user intent rather than using a null value
+case "${USE_SUSPSYNC,,}" in
+  y|yes|true|t|on|1|enabled|enable|use)
+    SUSPSYNC=1
+    ;;
+  *)
+    SUSPSYNC=0
     ;;
 esac
 
@@ -187,8 +197,10 @@ dep_check() {
     exit 1
   fi
   if ! command -v gdbus >/dev/null 2>&1; then
-    echo -e " ${BLD}I require gdbus but it's not installed. ${RED}Aborting!${NRM}"
-    exit 1
+    if [[ $SUSPSYNC -eq 1 ]]; then
+      echo -e " ${BLD}I require gdbus but it's not installed. ${RED}Aborting!${NRM}"
+      exit 1
+    fi
   fi
   if [[ $OLFS -eq 1 ]]; then
     [[ $OLFSVER -ge 22 ]] || {
@@ -526,6 +538,7 @@ do_sync() {
       echo "# will be applied the _next_ time psd is activated."
       echo "#"
       echo "USE_OVERLAYFS=\"$USE_OVERLAYFS\""
+      echo "USE_SUSPSYNC=\"$USE_SUSPSYNC\""
       echo "BROWSERS=\"${BROWSERS[*]}\""
       echo "USE_BACKUPS=\"$USE_BACKUPS\""
     } >> "$PSDCONFDIR/.psd.conf"
@@ -728,7 +741,7 @@ case "$1" in
       dup_check
       running_check
       ungraceful_state_check
-      take_inhibit_lock
+      [[ $SUSPSYNC -eq 1 ]] && take_inhibit_lock
       echo -e "${BLD}psd startup check successful${NRM}"
     fi
     ;;
@@ -759,7 +772,7 @@ case "$1" in
       do_sync
       kill_browsers
       do_unsync
-      release_inhibit_lock
+      [[ $SUSPSYNC -eq 1 ]] && release_inhibit_lock
     fi
     ;;
   *)

--- a/common/psd-suspend-sync
+++ b/common/psd-suspend-sync
@@ -14,7 +14,7 @@ dbus_member="PrepareForSleep"
 # ... /org/freedesktop/login1: org.freedesktop.login1.Manager.PrepareForSleep (false,) ...
 gdbus monitor --system --dest "$dbus_interface" | \
     while read -r line; do
-	if [[ "$line" =~ "$dbus_member" ]]; then
+	if [[ "$line" =~ $dbus_member ]]; then
 	    if [[ "$line" =~ "true" ]]; then
 		### SUSPEND ###
 		logger "[psd-suspend-sync] Issueing suspend-sync request..."

--- a/common/psd-suspend-sync
+++ b/common/psd-suspend-sync
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#
+# psd sync on suspend
+# https://github.com/graysky2/profile-sync-daemon/issues/231
+#
+
+dbus_interface="org.freedesktop.login1"
+dbus_member="PrepareForSleep"
+
+# system suspends when 'PrepareForSleep' signal is 'true':
+# ... /org/freedesktop/login1: org.freedesktop.login1.Manager.PrepareForSleep (true,) ...
+# system resumes when 'PrepareForSleep' signal is 'false'
+# ... /org/freedesktop/login1: org.freedesktop.login1.Manager.PrepareForSleep (false,) ...
+gdbus monitor --system --dest "$dbus_interface" | \
+    while read -r line; do
+	if [[ "$line" =~ "$dbus_member" ]]; then
+	    if [[ "$line" =~ "true" ]]; then
+		### SUSPEND ###
+		logger "[psd-suspend-sync] Issueing suspend-sync request..."
+		/usr/bin/profile-sync-daemon suspend-sync
+		# the lock will be released now
+	    elif [[ "$line" =~ "false" ]]; then
+		### RESUME ###
+		logger "[psd-suspend-sync] re-taking inhibit lock..."
+		/usr/bin/profile-sync-daemon recycle-inhibit-lock
+	    fi
+	fi
+    done
+
+#exit 0

--- a/common/psd.conf
+++ b/common/psd.conf
@@ -14,6 +14,11 @@
 #
 #USE_OVERLAYFS="no"
 
+# Uncomment and set to "yes" to resync on suspend to reduce potential data loss.
+# Note that your system MUST have gdbus from glib2 installed to use this mode.
+#
+#USE_SUSPSYNC="no"
+
 # List any browsers in the array below to have managed by psd. Useful if you do
 # not wish to have all possible browser profiles managed which is the default if
 # this array is left commented.


### PR DESCRIPTION
After some reading I wanted to _try_ implementing `suspend-sync` (see #231) with as little impact as possible, honoring psd's goal of being a userland application. Wording/file naming etcetera are up for debate, but the functionality **seems** to be working as expected.

The only added dependency is on `glib2` (for `gdbus`), but IMO this shouldn't cause too much trouble, as most if not all OS'es will have this available via official repositories.

Extensive testing is advised, as there are quite a few variables in play here.