### PR TITLE
Add Brave browser

### DIFF
--- a/common/browsers/brave
+++ b/common/browsers/brave
@@ -1,0 +1,2 @@
+DIRArr[0]="$XDG_CONFIG_HOME/BraveSoftware/Brave-Browser"
+PSNAME="brave"


### PR DESCRIPTION
It would be great if you could add Brave support. :)

```
$ psd p
Profile-sync-daemon v6.40

 systemd service: active
 resync-timer:    active
 sync on sleep:   disabled
 use overlayfs:   disabled

Psd will manage the following per /home/archie/.config/psd/.psd.conf:

 browser/psname:  brave/brave
 owner/group id:  archie/1000
 sync target:     /home/archie/.config/BraveSoftware/Brave-Browser
 tmpfs dir:       /run/user/1000/archie-brave
 profile size:    400M
 recovery dirs:   none

 browser/psname:  chromium/chromium
 owner/group id:  archie/1000
 sync target:     /home/archie/.config/chromium
 tmpfs dir:       /run/user/1000/archie-chromium
 profile size:    151M
 recovery dirs:   none

 browser/psname:  firefox/firefox
 owner/group id:  archie/1000
 sync target:     /home/archie/.mozilla/firefox/abc.dev-edition-default
 tmpfs dir:       /run/user/1000/archie-firefox-abc.dev-edition-default
 profile size:    422M
 recovery dirs:   none
```

Please let me know if more testing should be done. So far this seems to work fine. :)