### PR TITLE
Change rsync argument for copying legacy config

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -66,7 +66,7 @@ elif [[ -d "$HOME/.psd" ]]; then
   # first check to see if a legacy ~/.psd is present and then move it to the
   # new location
   mkdir -p "$PSDCONFDIR"
-  rsync -ax "$HOME/.psd/" "$PSDCONFDIR/"
+  rsync -aX "$HOME/.psd/" "$PSDCONFDIR/"
   rm -rf "$HOME/.psd"
   echo " The use of $HOME/.psd is deprecated. Existing config has been moved to $PSDCONFDIR"
   # source it again retaining any user options


### PR DESCRIPTION
From -x(same filesystem) to -X(keep extended attributes). It was
probably mistyped.