### PR TITLE
Use CHROME_CONFIG_HOME as chrome profile location

### DIFF
--- a/common/browsers/google-chrome
+++ b/common/browsers/google-chrome
@@ -1,2 +1,6 @@
-DIRArr[0]="$XDG_CONFIG_HOME/$browser"
+if [[ -n "$CHROME_CONFIG_HOME" ]]; then
+    DIRArr[0]="$CHROME_CONFIG_HOME/$browser"
+else
+    DIRArr[0]="$XDG_CONFIG_HOME/$browser"
+fi
 PSNAME="chrome"

--- a/common/browsers/google-chrome-beta
+++ b/common/browsers/google-chrome-beta
@@ -1,2 +1,6 @@
-DIRArr[0]="$XDG_CONFIG_HOME/$browser"
+if [[ -n "$CHROME_CONFIG_HOME" ]]; then
+    DIRArr[0]="$CHROME_CONFIG_HOME/$browser"
+else
+    DIRArr[0]="$XDG_CONFIG_HOME/$browser"
+fi
 PSNAME="chrome"

--- a/common/browsers/google-chrome-unstable
+++ b/common/browsers/google-chrome-unstable
@@ -1,2 +1,6 @@
-DIRArr[0]="$XDG_CONFIG_HOME/$browser"
+if [[ -n "$CHROME_CONFIG_HOME" ]]; then
+    DIRArr[0]="$CHROME_CONFIG_HOME/$browser"
+else
+    DIRArr[0]="$XDG_CONFIG_HOME/$browser"
+fi
 PSNAME="chrome"


### PR DESCRIPTION
When set, use CHROME_CONFIG_HOME as the chrome profile location, as this
environment variable allows you to override the profile directory.

See also:
https://chromium.googlesource.com/chromium/src/+/HEAD/docs/user_data_dir.md