### PR TITLE
psd-suspend-sync generate orphan process and multi-user problem

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -713,13 +713,15 @@ parse() {
 take_inhibit_lock() {
   # ensure we only take one lock at a time
   release_inhibit_lock
-
-  # background this to avoid hanging on startup
   /usr/bin/psd-suspend-sync &
 }
 
 release_inhibit_lock() {
-  [[ "$(pgrep -cf "psd-suspend-sync")" != 0 ]] && pkill -f psd-suspend-sync
+  # user name is needed for multi-user systems
+  if [[ "$(pgrep -u "$user" -cf "gdbus monitor --system --dest org.freedesktop.login1")" != 0 ]]; then
+    pkill -u "$user" -f "gdbus monitor --system --dest org.freedesktop.login1"
+  fi
+  [[ "$(pgrep -u "$user" -cf "psd-suspend-sync")" != 0 ]] && pkill -u "$user" -f "psd-suspend-sync"
 }
 
 case "$1" in
@@ -755,10 +757,6 @@ case "$1" in
       # system preparing for sleep mode, resync when psd is active
       do_sync
     fi
-    ;;
-  recycle-inhibit-lock)
-    # take inhibit lock for next suspend cycle
-    take_inhibit_lock
     ;;
   sync|resync)
     if [[ -f $PID_FILE ]]; then

--- a/common/psd-suspend-sync
+++ b/common/psd-suspend-sync
@@ -2,13 +2,28 @@
 
 dbus_interface="org.freedesktop.login1"
 dbus_member="PrepareForSleep"
+# user name is needed for multi-user systems
+user=$(id -un)
+
+setting_inhibitor() {
+  # ensure we only take one lock at a time
+  if [[ "$(pgrep -u "$user" -cf "systemd-inhibit --mode=delay --what=sleep --who=profile-sync-daemon --why=psd resync on suspend")" != 0 ]]; then
+    pkill -u "$user" -f "systemd-inhibit --mode=delay --what=sleep --who=profile-sync-daemon --why=psd resync on suspend"
+  fi
+  # Note: the risk of malfunction would not have too much consequence,
+  # due to the option --mode = "delay" (timeout: InhibitDelayMaxSec = 5s)
+  systemd-inhibit --mode="delay" --what="sleep" --who="profile-sync-daemon" --why="psd resync on suspend" sleep inf  &
+  psd_inhibit_PID=$!
+}
+
+# take inhibit lock
+setting_inhibitor
 
 # system suspends when 'PrepareForSleep' signal is 'true':
 # ... /org/freedesktop/login1: org.freedesktop.login1.Manager.PrepareForSleep (true,) ...
 # system resumes when 'PrepareForSleep' signal is 'false'
 # ... /org/freedesktop/login1: org.freedesktop.login1.Manager.PrepareForSleep (false,) ...
-dbus_process_sleep() {
-  local line
+gdbus monitor --system --dest "$dbus_interface" | \
   while read -r line; do
     if [[ "$line" =~ $dbus_member ]]; then
       if [[ "$line" =~ 'true' ]]; then
@@ -16,30 +31,14 @@ dbus_process_sleep() {
         logger '[psd-suspend-sync] Issuing suspend-sync request...'
         /usr/bin/profile-sync-daemon suspend-sync
         # the lock will be released now
-        break
+        [[ ! -z "$psd_inhibit_PID" ]] && kill "$psd_inhibit_PID"
       elif [[ "$line" =~ 'false' ]]; then
         ### RESUME ###
         logger '[psd-suspend-sync] re-taking inhibit lock...'
-        /usr/bin/profile-sync-daemon recycle-inhibit-lock
-        break
+        # take inhibit lock for the next sleep cycle
+        setting_inhibitor
       fi
     fi
   done
-}
-
-coproc bus (
-  systemd-inhibit --mode="delay" --what="sleep" \
-    --who="profile-sync-daemon" --why="psd resync on suspend" \
-    gdbus monitor --system --dest "$dbus_interface"
-)
-
-# keeps the inhibitor running until the system is about to sleep
-dbus_process_sleep <& "${bus[0]}"
-
-# starts running before the system goes to sleep
-dbus_process_sleep < <(gdbus monitor --system --dest "$dbus_interface") &
-
-# kill the inhibitor so that the system can sleep
-[ ! -z "$bus_PID" ] && kill "$bus_PID"
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
I did some tests today with the suspend-sync function.
I was able to verify that following the improvement made by **smac89** (# 276) that inhibit lock is functional (I was able to reproduce the problem with the previous version and see the expiration of the `InhibitDelayMaxSec` timeout).

There is one more problem that remains:
A process `gdbus monitor --system --dest org.freedesktop.login1` becomes orphan after **each** resume.
That's because killing the script `psd-suspend-sync` does not stop this process.

In addition, I found that killing the script `psd-suspend-sync` after each resume and restarting 2 `gdbus` processes by cycle (one process initialized with the `coproc` for suspend (when creating the inhibit lock) and one process for resume), is not optimal.

On the other hand, the `release_inhibit_lock ()` function of the main script will try to kill the `psd-suspend-sync` script regardless of the user (because of the `pgrep -cf "psd-suspend-sync"` command) and will generate error messages. This situation is problematic in a multi-user environment.


The proposed changes correct these problems. 