### PR TITLE
Fix-#310-running-Firefox-94.0-detection

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -372,6 +372,23 @@ load_env_for() {
   . "$SHAREDIR/browsers/$browser"
 }
 
+running_browser_pid() {
+  local pid_list geckomain_pid
+
+  PSNAME_PID="$(pgrep -x -u "$user" "$PSNAME")"
+  # needed for browser using a process name different than application name
+  # e.g. GeckoMain for firefox or librewolf
+  if [[ -z "$PSNAME_PID" ]]; then
+    pid_list="$(pgrep -u "$user" -f "$PSNAME")"
+    if [[ -n "$pid_list" ]]; then
+      geckomain_pid="$(ps h -C GeckoMain -o pid:1)"
+      if [[ -n "$geckomain_pid" ]]; then
+        PSNAME_PID="$( grep "$geckomain_pid" <<< "$pid_list" )"
+      fi
+    fi
+  fi
+}
+
 running_check() {
   # check for browsers running and refuse to start if so
   # without this cannot guarantee profile integrity
@@ -379,7 +396,8 @@ running_check() {
   for browser in "${BROWSERS[@]}"; do
     load_env_for "$browser"
     [[ -z "$PSNAME" ]] && continue
-    if pgrep -x -u "$user" "$PSNAME" &>/dev/null; then
+    running_browser_pid
+    if [[ -n "$PSNAME_PID" ]]; then
       echo "Refusing to start; $browser is running by $user!"
       exit 1
     fi
@@ -433,12 +451,13 @@ kill_browsers() {
     local x=1
     while [[ $x -le 60 ]]; do
       [[ -n "$PSNAME" ]] || break
-      pgrep -x -u "$user" "$PSNAME" &>/dev/null || break
+      running_browser_pid
+      [[ -n "$PSNAME_PID" ]] || break
 
       if [[ $x -le 5 ]]; then
-        pkill -x -SIGTERM -u "$user" "$PSNAME"
+        kill -SIGTERM "${PSNAME_PID//$'\n'/' '}"
       else
-        pkill -x -SIGKILL -u "$user" "$PSNAME"
+        kill -SIGKILL "${PSNAME_PID//$'\n'/' '}"
       fi
 
       x=$(( x + 1 ))


### PR DESCRIPTION
Solution meeting the following constraints:

- In the standard case, the commands currently used are correct `pgrep/pkill -x -u "$user" "$PSNAME"`
- For Firefox, Librewolf (or other?), do not use the command line pattern only: in this case all the processes and sub-processes containing the word 'firefox' in their command line will be taken into account for detection ( `running_check ()`) and stopped (`kill_browsers ()`).
- Do not rely solely on the process name` 'GeckoMain'` => how to differentiate Firefox and Librewolf for example?
- Case scenario: psd configured with `BROWSERS=firefox`
    a) `leafpad firefox_text` running => psd does not start if you match the command line only.
    b) `librewolf` running => psd does not start believing it is firefox (do not rely solely on the name of the process `'GeckoMain'`)
    c) `firefox + librewolf` running => 2 GeckoMain processes, but only one should be considered as running because `BROWSERS=firefox`
    d) For 2 simultaneous firefox processes running (possible with 2 different versions of firefox) => take into account the 2 `GeckoMain` processes
