### PR TITLE
Add support for opendoas

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -26,6 +26,8 @@ PSDCONF="$PSDCONFDIR/psd.conf"
 SHAREDIR="/usr/share/psd"
 VOLATILE="$XDG_RUNTIME_DIR"
 PID_FILE="$VOLATILE/psd.pid"
+SUDO="sudo"
+DOASDIR="/usr/bin/doas"
 
 if [[ ! -d "$SHAREDIR" ]]; then
   echo -e " ${RED}ERROR:${NRM}${BLD} Missing ${BLU}$SHAREDIR${NRM}${BLD} - reinstall the package to use profile-sync-daemon.${NRM}"
@@ -227,7 +229,16 @@ config_check() {
     # user must have sudo rights to call /usr/bin/mount
     # and /usr/bin/umount to use overlay mode
 
-    if ! sudo -kn psd-overlay-helper &>/dev/null; then
+    # use doas in place of sudo if present
+    if [[ -d "$DOASDIR" ]]; then
+      SUDO="doas"
+      tmp_sudo = "doas"
+    else
+      tmp_sudo = "sudo -kn"
+    fi
+
+    # verify user has sudo rights
+    if ! $tmp_sudo psd-overlay-helper &>/dev/null; then
       FAILCODE=1
     fi
 
@@ -497,7 +508,7 @@ do_sync_for() {
         # initial sync
         REPORT="sync"
         if [[ $OLFS -eq 1 ]]; then
-          if ! sudo psd-overlay-helper -v "$OLFSVER" -l "$BACKUP" -u "$UPPER" -w "$WORK" -d "$TMP" mountup; then
+          if ! $SUDO psd-overlay-helper -v "$OLFSVER" -l "$BACKUP" -u "$UPPER" -w "$WORK" -d "$TMP" mountup; then
             echo -e "Error in trying to mount $TMP - this should not happen!"
             exit 1
           fi
@@ -596,7 +607,7 @@ do_unsync() {
         [[ -d "$BACKUP" ]] && mv --no-target-directory "$BACKUP" "$DIR"
         if [[ $OLFS -eq 1 ]] && mountpoint -q "$TMP"; then
           rsync -aX --delete-after --inplace --no-whole-file --exclude .flagged "$BACK_OVFS/" "$DIR/"
-          sudo psd-overlay-helper -d "$TMP" -w "$WORK" mountdown && rm -rf "$TMP" "$UPPER"
+          $SUDO psd-overlay-helper -d "$TMP" -w "$WORK" mountdown && rm -rf "$TMP" "$UPPER"
         fi
         [[ -d "$TMP" ]] && rm -rf "$TMP"
         echo -e "${BLD}$browser unsync successful${NRM}"


### PR DESCRIPTION
I'm one of those weirdos that uses doas instead of sudo, and like issue #322 mentions. a symlink from doas to sudo usually makes most programs work but the special "-k" option used here breaks it. This PR adds proper support for using doas, automatically using it if it is installed.