### PR TITLE
Add VSCode 'Browser' to PSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ User of eCryptFS are encouraged not to use psd unless willing to help troublesho
 * Seamonkey
 * Surf (http://surf.suckless.org/)
 * Vivaldi-browser and Vivaldi-browser-snapshot
+* VS Code
 
 ## Documentation
 Consult the man page or the wiki page: https://wiki.archlinux.org/index.php/Profile-sync-daemon

--- a/common/browsers/vscode
+++ b/common/browsers/vscode
@@ -1,0 +1,2 @@
+DIRArr[0]="$XDG_CONFIG_HOME/Code"
+PSNAME="vscode"

--- a/common/psd.conf
+++ b/common/psd.conf
@@ -52,6 +52,7 @@
 #  surf
 #  vivaldi
 #  vivaldi-snapshot
+#  vscode
 #
 #BROWSERS=()
 


### PR DESCRIPTION
I figured since VS Code was essentially chromium with some stuff bolted on, it would be straightforward to handle it in the same way. Imagine my delight when it only required a single file to be changed. Code OSS would be equally straightforward.