### PR TITLE
Fix `surf` support (rm wrong '/')

### DIFF
--- a/common/browsers/surf
+++ b/common/browsers/surf
@@ -1,2 +1,2 @@
-DIRArr[0]="$HOME/.$browser/"
+DIRArr[0]="$HOME/.$browser"
 PSNAME="$browser"


### PR DESCRIPTION
This trailing slash prevented `psd` to form a proper dir-name for backup/overlay. As a result, `psd` did not work properly with `surf`, issuing the message:

    stat: cannot statx '~/.surf/-backup': No such file or directory.

Note, that `surf` keeps its config in `~/.surf`. Before this fix, the resulting backup dir was `~/.surf/-backup`, not `~/.surf-backup` as it should be.
This means that `psd` tried to create the backup inside the dir which it supposed to make backup of!  8()
After removing this unfortunate '/', `psd` works with `surf` correctly, creating the proper dirs: `~/.surf-backup` and `~/.surf-back-ovfs`, with overlay:

    sync target:  /home/elf/.surf
    tmpfs dir:    /run/user/1000/elf-surf

Most importantly, none of the other browser's configs (in `/usr/share/psd/browsers/*`) contains such trailing '/'. So, this is certainly a bug and nothing else.

Thanks for you work on this Daemon! : )
