### PR TITLE
feature: Support for snapped versions of Firefox and Chromium

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -368,6 +368,11 @@ suffix_needed() {
   [[ -n "$check_suffix" ]]
 }
 
+infix_needed() {
+  browser=$1
+  [[ $browser == *"-in-snap" ]]
+}
+
 dup_check() {
   # only for firefox, icecat, seamonkey, and palemoon
   # the LAST directory in the profile MUST be unique
@@ -429,13 +434,17 @@ do_sync_for() {
     DIR="$item"
     BACKUP="$item-backup"
     BACK_OVFS="$item-back-ovfs"
+    infix=
+    if infix_needed "$browser"; then
+      infix="../snap.${browser%-in-snap}/"
+    fi
     suffix=
     if suffix_needed "$browser"; then
       suffix="-${item##*/}"
     fi
-    TMP="$VOLATILE/$user-$browser$suffix"
-    UPPER="$VOLATILE/$user-$browser${suffix}-rw"
-    WORK="$VOLATILE/.$user-$browser${suffix}"
+    TMP="$VOLATILE/$infix$user-$browser$suffix"
+    UPPER="$VOLATILE/$infix$user-$browser${suffix}-rw"
+    WORK="$VOLATILE/$infix.$user-$browser${suffix}"
     local REPORT
 
     # make tmpfs container
@@ -554,13 +563,17 @@ do_unsync() {
       DIR="$item"
       BACKUP="$item-backup"
       BACK_OVFS="$item-back-ovfs"
+      infix=
+      if infix_needed "$browser"; then
+        infix="../snap.${browser%-in-snap}/"
+      fi
       suffix=
       if suffix_needed "$browser"; then
         suffix="-${item##*/}"
       fi
-      TMP="$VOLATILE/$user-$browser$suffix"
-      UPPER="$VOLATILE/$user-$browser${suffix}-rw"
-      WORK="$VOLATILE/.$user-$browser${suffix}"
+      TMP="$VOLATILE/$infix$user-$browser$suffix"
+      UPPER="$VOLATILE/$infix$user-$browser${suffix}-rw"
+      WORK="$VOLATILE/$infix.$user-$browser${suffix}"
       # check if user has browser profile
       if [[ -h "$DIR" ]]; then
         unlink "$DIR"
@@ -634,11 +647,15 @@ parse() {
     for item in "${DIRArr[@]}"; do
       DIR="$item"
       BACKUP="$item-backup"
+      infix=
+      if infix_needed "$browser"; then
+        infix="../snap.${browser%-in-snap}/"
+      fi
       suffix=
       if suffix_needed "$browser"; then
         suffix="-${item##*/}"
       fi
-      UPPER="$VOLATILE/$user-$browser${suffix}-rw"
+      UPPER="$VOLATILE/$infix$user-$browser${suffix}-rw"
       if [[ -d "$DIR" ]]; then
         local CRASHArr=()
         while IFS= read -d '' -r backup; do
@@ -668,7 +685,7 @@ parse() {
           warn=
         fi
         echo -en " ${BLD}tmpfs dir:"
-        echo -e "$(tput cr)$(tput cuf 17) ${GRN}$VOLATILE/$user-$browser$suffix${NRM}"
+        echo -e "$(tput cr)$(tput cuf 17) ${GRN}$VOLATILE/$infix$user-$browser$suffix${NRM}"
         echo -en " ${BLD}profile size:"
         echo -e "$(tput cr)$(tput cuf 17) $psize${NRM}"
         if [[ -f $PID_FILE ]]; then

--- a/contrib/chromium-in-snap
+++ b/contrib/chromium-in-snap
@@ -1,0 +1,2 @@
+DIRArr[0]="$HOME/snap/chromium/common/chromium"
+PSNAME="chromium"

--- a/contrib/firefox-in-snap
+++ b/contrib/firefox-in-snap
@@ -1,0 +1,17 @@
+if [[ -d "$HOME/snap/firefox/common/.mozilla/firefox" ]]; then
+    index=0
+    PSNAME="firefox"
+    while read -r profileItem; do
+        if [[ $(echo "$profileItem" | cut -c1) = "/" ]]; then
+            # path is not relative
+            DIRArr[$index]="$profileItem"
+        else
+            # we need to append the default path to give a
+            # fully qualified path
+            DIRArr[$index]="$HOME/snap/firefox/common/.mozilla/firefox/$profileItem"
+        fi
+        (( index=index+1 ))
+    done < <(grep '^[Pp]ath=' "$HOME/snap/firefox/common/.mozilla/firefox/profiles.ini" | sed 's/[Pp]ath=//')
+fi
+
+check_suffix=1


### PR DESCRIPTION
In response to Canonical's high-pressure selling of Snapcraft.

## Snap in brief

Snap applies auto-generated AppArmor profiles located in `/var/lib/snapd/apparmor/profiles/`. [Profile template](https://github.com/snapcore/snapd/blob/release/2.57/interfaces/apparmor/template.go#L380-L383) and [data to populate the template](https://github.com/snapcore/snapd/blob/release/2.57/interfaces/apparmor/template_vars.go#L37).

These profiles restrict access to `$XDG_RUNTIME_DIR` (as reported in https://github.com/graysky2/profile-sync-daemon/issues/247), and at the same time allow access to specific `$XDG_RUNTIME_DIR`'s subdirectories, so `$XDG_RUNTIME_DIR/snap.firefox/` is accessible to snapped Firefox, and `$XDG_RUNTIME_DIR/snap.chromium/` is accessible to snapped Chromium.

Browser profiles are located in `~/snap/$SNAP_INSTANCE_NAME/common/` (`~/snap/firefox/common/` and `~/snap/chromium/common/` respectively).

## Possible solution

To comply with AppArmor restrictions mentioned above the in-memory part needs to be rerouted from the root of `$VOLATILE` to respective subdirectories of it.


Tested on Ubuntu 22.04.1 .