### PR TITLE
Move $VOLATILE to dedicated directory in $XDG_RUNTIME_DIR

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -35,8 +35,8 @@ XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 PSDCONFDIR="$XDG_CONFIG_HOME/psd"
 PSDCONF="$PSDCONFDIR/psd.conf"
 SHAREDIR="/usr/share/psd"
-VOLATILE="$XDG_RUNTIME_DIR"
-PID_FILE="$VOLATILE/psd.pid"
+VOLATILE="$XDG_RUNTIME_DIR/psd"
+PID_FILE="$XDG_RUNTIME_DIR/psd.pid"
 
 if [[ ! -d "$SHAREDIR" ]]; then
   echo -e " ${RED}ERROR:${NRM}${BLD} Missing ${BLU}$SHAREDIR${NRM}${BLD} - reinstall the package to use profile-sync-daemon.${NRM}"


### PR DESCRIPTION
This is required to share the synced profiles with Flatpak executables.

Explanation: $XDG_RUNTIME_DIR can't be shared with sandboxes, so the symlinked profile directories aren't accessible. However, selected directories inside it can be shared, therefore this change allows Flatpak-ed browsers to use psd by sharing `$XDG_RUNTIME_DIR` with them.

Keeps $PID_FILE in the same location for compatibility purposes, in case any daemons or service units depend on that.

To use with Flatpak, share `xdg-run/psd` with the sandbox, i.e. `flatpak override --filesystem=xdg-run/psd <application id>`. I'll try and contribute with Flathub to have that by default.

**How to use?**

I slightly modified the Firefox script to find directories inside the Flatpak sandbox, changing the base directory from `$HOME` to `$HOME/.var/app/org.mozilla.firefox` was enough:

```sh
BASEDIR="$HOME/.var/app/org.mozilla.firefox"

if [[ -d "$BASEDIR/.mozilla/firefox" ]]; then
    index=0
    PSNAME="firefox-bin"
    while read -r profileItem; do
        if [[ $(echo "$profileItem" | cut -c1) = "/" ]]; then
            # path is not relative
            DIRArr[$index]="$profileItem"
        else
            # we need to append the default path to give a
            # fully qualified path
            DIRArr[$index]="$BASEDIR/.mozilla/firefox/$profileItem"
        fi
        (( index=index+1 ))
    done < <(grep '[Pp]'ath= "$BASEDIR/.mozilla/firefox/profiles.ini" | sed 's/[Pp]ath=//')
fi

check_suffix=1
```

psd could either have separate scripts for Flatpak-ed versions, or just check both locations with the same script.