### PR TITLE
Create XDG_RUNTIME_DIR in /tmp if not set

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -30,13 +30,12 @@ VERS="@VERSION@"
 
 user=$(id -un)
 HOME="$(getent passwd "$user" | cut -d: -f6)"
+TMPDIR="${TMPDIR:-/tmp}"
 XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
 XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 PSDCONFDIR="$XDG_CONFIG_HOME/psd"
 PSDCONF="$PSDCONFDIR/psd.conf"
 SHAREDIR="/usr/share/psd"
-VOLATILE="$XDG_RUNTIME_DIR/psd"
-PID_FILE="$XDG_RUNTIME_DIR/psd.pid"
 
 if [[ ! -d "$SHAREDIR" ]]; then
   echo -e " ${RED}ERROR:${NRM}${BLD} Missing ${BLU}$SHAREDIR${NRM}${BLD} - reinstall the package to use profile-sync-daemon.${NRM}"
@@ -53,10 +52,30 @@ if [[ $EUID -eq 0 ]]; then
   exit 1
 fi
 
-if [[ ! -d "$XDG_RUNTIME_DIR" ]]; then
+# Create an XDG_RUNTIME_DIR if not given one (i.e. running without DE)
+# See https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+if [[ -z "$XDG_RUNTIME_DIR" ]]; then
+  XDG_RUNTIME_DIR="${TMPDIR}/runtime-${user}"
+  echo -e " ${RED}WARNING:${NRM}${BLD} XDG_RUNTIME_DIR not set, defaulting to '${XDG_RUNTIME_DIR}'.${NRM}"
+  if [[ ! -d "$XDG_RUNTIME_DIR" ]] && ! mkdir "$XDG_RUNTIME_DIR"; then
+    echo -e " ${RED}ERROR:${NRM}${BLD} Unable to create runtime directory '${XDG_RUNTIME_DIR}'.${NRM}"
+    exit 1
+  fi
+  if ! chown "${user}" "${XDG_RUNTIME_DIR}"; then
+    echo -e " ${RED}ERROR:${NRM}${BLD} Unable to make user '${user}' owner of runtime directory '${XDG_RUNTIME_DIR}'.${NRM}"
+    exit 1
+  fi
+  if ! chmod 0700 "${XDG_RUNTIME_DIR}"; then
+    echo -e " ${RED}ERROR:${NRM}${BLD} Uname to make runtime directory '${XDG_RUNTIME_DIR}' only accessible to user '$user'.${NRM}"
+    exit 1
+  fi
+elif [[ ! -d "$XDG_RUNTIME_DIR" ]]; then
   echo -e " ${RED}ERROR:${NRM}${BLD} Cannot find XDG_RUNTIME_DIR which should be set by systemd.${NRM}"
   exit 1
 fi
+
+VOLATILE="$XDG_RUNTIME_DIR/psd"
+PID_FILE="$XDG_RUNTIME_DIR/psd.pid"
 
 # Setup check for config file
 if [[ -f "$PSDCONF" ]]; then


### PR DESCRIPTION
This addresses Issue #343 and, per the XDG specification and standard practice, creates and sets `XDG_RUNTIME_DIR` to `/tmp/${USER}-runtime/` if `XDG_RUNTIME_DIR` is not set. This makes `profile-sync-daemon` function properly when using a window manager without a desktop environment that sets `XDG_RUNTIME_DIR`.