### PR TITLE
Add community support for Floorp and Thorium Browsers

### DIFF
--- a/contrib/floorp
+++ b/contrib/floorp
@@ -1,0 +1,17 @@
+if [[ -d "$HOME"/.floorp ]]; then
+    index=0
+    PSNAME="$browser"
+    while read -r profileItem; do
+        if [[ $(echo "$profileItem" | cut -c1) = "/" ]]; then
+            # path is not relative
+            DIRArr[$index]="$profileItem"
+        else
+            # we need to append the default path to give a
+            # fully qualified path
+            DIRArr[$index]="$HOME/.floorp/$profileItem"
+        fi
+        (( index=index+1 ))
+    done < <(grep '[Pp]'ath= "$HOME"/.floorp/profiles.ini | sed 's/[Pp]ath=//')
+fi
+
+check_suffix=1

--- a/contrib/thorium
+++ b/contrib/thorium
@@ -1,0 +1,2 @@
+DIRArr[0]="$XDG_CONFIG_HOME/$browser"
+PSNAME="$browser"


### PR DESCRIPTION
Commit adds support for the Floorp Browser, a highly configurable and a fairly unique fork of Firefox that's picking up steam as of late.

Noticed https://github.com/graysky2/profile-sync-daemon/issues/369 where the person figured out how to add support but didn't send a PR to add it to the contrib directory, the commit is mostly to make things simpler for me when I have to set up a whole bunch of Mini-PCs around the house real soon :D 

Thank you for the amazing project, my single-purpose shitboxes do their job so much better now ;-;