### PR TITLE
Assign PSD to background slice

### DIFF
--- a/init/psd-resync.service
+++ b/init/psd-resync.service
@@ -5,6 +5,7 @@ Wants=psd-resync.timer
 BindsTo=psd.service
 
 [Service]
+Slice=background.slice
 Type=oneshot
 ExecStart=/usr/bin/profile-sync-daemon resync
 Environment=LAUNCHED_BY_SYSTEMD=1

--- a/init/psd.service
+++ b/init/psd.service
@@ -7,6 +7,7 @@ RequiresMountsFor=/home/
 After=winbindd.service
 
 [Service]
+Slice=background.slice
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/profile-sync-daemon startup


### PR DESCRIPTION
Backup services are not critical to latency, so they can be given fewer resources.