### PR TITLE
Add Firefox Flatpak support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ User of eCryptFS are encouraged not to use psd unless willing to help troublesho
 * Conkeror
 * Epiphany
 * Firefox (stable, beta, and aurora)
+* Firefox Flatpak (run `flatpak override --user org.mozilla.firefox --filesystem=/run/user/$UID/psd` once to give required access)
 * Firefox-trunk (this is an Ubuntu-only browser: http://www.webupd8.org/2011/05/install-firefox-nightly-from-ubuntu-ppa.html)
 * Google Chrome (stable, beta, and dev)
 * Heftig's version of Aurora (this is an Arch Linux-only browser: https://bbs.archlinux.org/viewtopic.php?id=117157)

--- a/common/browsers/firefox-flatpak
+++ b/common/browsers/firefox-flatpak
@@ -1,0 +1,17 @@
+if [[ -d "$HOME"/.var/app/org.mozilla.firefox/.mozilla/firefox ]]; then
+    index=0
+    PSNAME="$browser"
+    while read -r profileItem; do
+        if [[ $(echo "$profileItem" | cut -c1) = "/" ]]; then
+            # path is not relative
+            DIRArr[$index]="$profileItem"
+        else
+            # we need to append the default path to give a
+            # fully qualified path
+            DIRArr[$index]="$HOME/.var/app/org.mozilla.firefox/.mozilla/firefox/$profileItem"
+        fi
+        (( index=index+1 ))
+    done < <(grep '[Pp]'ath= "$HOME"/.var/app/org.mozilla.firefox/.mozilla/firefox/profiles.ini | sed 's/[Pp]ath=//')
+fi
+
+check_suffix=1

--- a/common/browsers/firefox-flatpak-cache
+++ b/common/browsers/firefox-flatpak-cache
@@ -1,0 +1,18 @@
+if [[ -d "$HOME"/.var/app/org.mozilla.firefox/.mozilla/firefox ]] && [[ -d "$HOME"/.var/app/org.mozilla.firefox/cache/mozilla/firefox ]]; then
+    index=0
+    PSNAME="$browser"
+    while read -r profileItem; do
+        if [[ $(echo "$profileItem" | cut -c1) = "/" ]]; then
+            # path is not relative, so we have to use basename
+            profileName=$(basename "$profileItem")
+            DIRArr[$index]="$HOME/.var/app/org.mozilla.firefox/cache/mozilla/firefox/$profileName"
+        else
+            # we need to append the default path to give a
+            # fully qualified path
+            DIRArr[$index]="$HOME/.var/app/org.mozilla.firefox/cache/mozilla/firefox/$profileItem"
+        fi
+        (( index=index+1 ))
+    done < <(grep '[Pp]'ath= "$HOME"/.var/app/org.mozilla.firefox/.mozilla/firefox/profiles.ini | sed 's/[Pp]ath=//')
+fi
+
+check_suffix=1

--- a/common/psd.conf
+++ b/common/psd.conf
@@ -22,6 +22,9 @@
 # List any browsers in the array below to have managed by psd. Useful if you do
 # not wish to have all possible browser profiles managed which is the default if
 # this array is left commented.
+# Note: If you want to use firefox-flatpak and firefox-flatpak-cache, you have
+# to add the psd-directory as an override:
+# flatpak override --user org.mozilla.firefox --filesystem=/run/user/$UID/psd
 #
 # Possible values:
 #  chromium
@@ -30,6 +33,8 @@
 #  epiphany
 #  falkon
 #  firefox
+#  firefox-flatpak
+#  firefox-flatpak-cache
 #  firefox-trunk
 #  google-chrome
 #  google-chrome-beta


### PR DESCRIPTION
Hi there,

i've created some dropins for Flatpak Firefox. I've also included one for the cache directory, although i'm not entirely sure how much write activity there actually is on that directory. Couldn't really find much info about that and haven't had time to investigate myself yet.
I'm running both dropins for a couple of days now an haven't noticed any issues.

One thing i'm uncertain about is the overrides situation. Obviously, Firefox needs to access the profile folder, so `/run/user/$UID/psd` needs to be added as an override with `flatpak override --user org.mozilla.firefox --filesystem=/run/user/$UID/psd`

Given that by default, all dropins are active, i think it might be a good idea to include something like
```
if ! flatpak override --user --show org.mozilla.firefox | grep -q "/run/user/$UID/psd"; then
    flatpak override --user org.mozilla.firefox --filesystem=/run/user/$UID/psd
fi
```
in both dropins.
I'd like to hear your opinion about that of course :)
    