### PR TITLE
Update zen - Modify path

### DIFF
--- a/contrib/zen
+++ b/contrib/zen
@@ -11,7 +11,7 @@ if [[ -d "$HOME"/.zen ]]; then
             DIRArr[$index]="$HOME/.zen/$profileItem"
         fi
         (( index=index+1 ))
-    done < <(grep '[Pp]'ath= "$HOME"/.zen/profiles.ini | sed 's/[Pp]ath=//')
+    done < <(grep '^[Pp]'ath= "$HOME"/.zen/profiles.ini | sed 's/^[Pp]ath=//')
 fi
 
 check_suffix=1


### PR DESCRIPTION
Zen uses "ZenAvatarPath" in it's profiles.ini and it messes up the backup. I've added the "^" character (beginning of line) for the grep and the sed command so it doesn't pickup "ZenAvatarPath" and only the lines that starts with "Path" or "path".