### PR TITLE
Support for FIrefox Nightly and new version of Firefox

### DIFF
--- a/contrib/firefox-nightly
+++ b/contrib/firefox-nightly
@@ -1,0 +1,17 @@
+if [[ -d "$HOME"/.config/mozilla/firefox ]]; then
+    index=0
+    PSNAME="$browser"
+    while read -r profileItem; do
+        if [[ $(echo "$profileItem" | cut -c1) = "/" ]]; then
+            # path is not relative
+            DIRArr[$index]="$profileItem"
+        else
+            # we need to append the default path to give a
+            # fully qualified path
+            DIRArr[$index]="$HOME/.config/mozilla/firefox/$profileItem"
+        fi
+        (( index=index+1 ))
+    done < <(grep '[Pp]'ath= "$HOME"/.config/mozilla/firefox/profiles.ini | sed 's/[Pp]ath=//')
+fi
+
+check_suffix=1


### PR DESCRIPTION
Support for Firefox Nightly and new version of Firefox with profiles in .config/mozilla/firefox
for use is need set "firefox-nightly" in BROWSER variable.