### PR TITLE
Update Zen Browser's profile dir & add Helium Browser support

### DIFF
--- a/contrib/zen
+++ b/contrib/zen
@@ -11,7 +11,7 @@ if [[ -d "$HOME"/.zen ]]; then
             DIRArr[$index]="$HOME/.zen/$profileItem"
         fi
         (( index=index+1 ))
-    done < <(grep '[Pp]'ath= "$HOME"/.zen/profiles.ini | sed 's/[Pp]ath=//')
+    done < <(grep '^[Pp]'ath= "$HOME"/.zen/profiles.ini | sed 's/^[Pp]ath=//')
 fi
 
 check_suffix=1

--- a/contrib/zen
+++ b/contrib/zen
@@ -1,3 +1,21 @@
+if [[ -d "$XDG_CONFIG_HOME/zen" ]]; then
+    index=0
+    PSNAME="$browser"
+    while read -r profileItem; do
+        if [[ $(echo "$profileItem" | cut -c1) = "/" ]]; then
+            # path is not relative
+            DIRArr[$index]="$profileItem"
+        else
+            # we need to append the default path to give a
+            # fully qualified path
+            DIRArr[$index]="$XDG_CONFIG_HOME/zen/$profileItem"
+        fi
+        (( index=index+1 ))
+    done < <(grep '^[Pp]ath=' "$XDG_CONFIG_HOME/zen/profiles.ini" | sed 's/^[Pp]ath=//')
+fi
+
+check_suffix=1
+
 if [[ -d "$HOME"/.zen ]]; then
     index=0
     PSNAME="$browser"
@@ -11,7 +29,7 @@ if [[ -d "$HOME"/.zen ]]; then
             DIRArr[$index]="$HOME/.zen/$profileItem"
         fi
         (( index=index+1 ))
-    done < <(grep '^[Pp]'ath= "$HOME"/.zen/profiles.ini | sed 's/^[Pp]ath=//')
+    done < <(grep '^[Pp]ath=' "$HOME"/.zen/profiles.ini | sed 's/^[Pp]ath=//')
 fi
 
 check_suffix=1


### PR DESCRIPTION
back again, updated Zen to reflect the latest XDG Base Dir spec update. Used the official Firefox impl as a base, and as a result still retain support for legacy profile directory as well.

While at it also added support for another new browser called Helium.

(wish i got the pr in before the release but oh well)

for users: the community supported config files are in `/usr/share/psd/contrib`

Cheers!

