### PR TITLE
Add LibreWolf support

### DIFF
--- a/contrib/librewolf
+++ b/contrib/librewolf
@@ -1,0 +1,36 @@
+if [[ -d "$XDG_CONFIG_HOME/librewolf/librewolf" ]]; then
+    index=0
+    PSNAME="$browser"
+    while read -r profileItem; do
+        if [[ $(echo "$profileItem" | cut -c1) = "/" ]]; then
+            # path is not relative
+            DIRArr[$index]="$profileItem"
+        else
+            # we need to append the default path to give a
+            # fully qualified path
+            DIRArr[$index]="$XDG_CONFIG_HOME/librewolf/librewolf/$profileItem"
+        fi
+        (( index=index+1 ))
+    done < <(grep '^[Pp]ath=' "$XDG_CONFIG_HOME/librewolf/librewolf/profiles.ini" | sed 's/[Pp]ath=//')
+fi
+
+check_suffix=1
+
+if [[ -d "$HOME"/.librewolf ]]; then
+    index=0
+    PSNAME="$browser"
+    while read -r profileItem; do
+        if [[ $(echo "$profileItem" | cut -c1) = "/" ]]; then
+            # path is not relative
+            DIRArr[$index]="$profileItem"
+        else
+            # we need to append the default path to give a
+            # fully qualified path
+            DIRArr[$index]="$HOME/.librewolf/$profileItem"
+        fi
+        (( index=index+1 ))
+    done < <(grep '^[Pp]ath=' "$HOME"/.librewolf/profiles.ini | sed 's/[Pp]ath=//')
+fi
+
+check_suffix=1
+


### PR DESCRIPTION
Add script for LibreWolf support. Copied from Firefox script and change the directories, honestly I'm not sure if LibreWolf actually uses the `$XDG_CONFIG_HOME/librewolf` directory but just kept that branch there just in case.

Tested on CachyOS.