### PR TITLE
zen: add support for $XDG_CONFIG_HOME

### DIFF
--- a/contrib/zen
+++ b/contrib/zen
@@ -1,3 +1,21 @@
+if [[ -d "$XDG_CONFIG_HOME/zen" ]]; then
+    index=0
+    PSNAME="$browser"
+    while read -r profileItem; do
+        if [[ $(echo "$profileItem" | cut -c1) = "/" ]]; then
+            # path is not relative
+            DIRArr[$index]="$profileItem"
+        else
+            # we need to append the default path to give a
+            # fully qualified path
+            DIRArr[$index]="$XDG_CONFIG_HOME/zen/$profileItem"
+        fi
+        (( index=index+1 ))
+    done < <(grep '^[Pp]ath=' "$XDG_CONFIG_HOME/zen/profiles.ini" | sed 's/^[Pp]ath=//')
+fi
+
+check_suffix=1
+
 if [[ -d "$HOME"/.zen ]]; then
     index=0
     PSNAME="$browser"
@@ -11,7 +29,7 @@ if [[ -d "$HOME"/.zen ]]; then
             DIRArr[$index]="$HOME/.zen/$profileItem"
         fi
         (( index=index+1 ))
-    done < <(grep '^[Pp]'ath= "$HOME"/.zen/profiles.ini | sed 's/^[Pp]ath=//')
+    done < <(grep '^[Pp]ath=' "$HOME"/.zen/profiles.ini | sed 's/^[Pp]ath=//')
 fi
 
 check_suffix=1


### PR DESCRIPTION
Updated Zen to reflect the latest XDG Base Directory spec update of Firefox and it's derivatives. Used the official Firefox implementation as a base, and as a result, this change still retains support for legacy profile directory @ `$HOME/.zen` as well.

for users: the community supported config files are in `/usr/share/psd/contrib`

closed the old PR to remove the Helium Browser addition and to clean up the commit history a little bit