### PR TITLE
ADD support for firefox ESR #334

### DIFF
--- a/common/browsers/firefox-esr
+++ b/common/browsers/firefox-esr
@@ -1,0 +1,36 @@
+if [[ -d "$XDG_CONFIG_HOME/mozilla/firefox-esr" ]]; then
+    index=0
+    PSNAME="$browser"
+    while read -r profileItem; do
+        if [[ $(echo "$profileItem" | cut -c1) = "/" ]]; then
+            # path is not relative
+            DIRArr[$index]="$profileItem"
+        else
+            # we need to append the default path to give a
+            # fully qualified path
+            DIRArr[$index]="$XDG_CONFIG_HOME/mozilla/firefox-esr/$profileItem"
+        fi
+        (( index=index+1 ))
+    done < <(grep '^[Pp]ath=' "$XDG_CONFIG_HOME/mozilla/firefox-esr/profiles.ini" | sed 's/[Pp]ath=//')
+fi
+
+check_suffix=1
+
+if [[ -d "$HOME"/.mozilla/firefox-esr ]]; then
+    index=0
+    PSNAME="$browser"
+    while read -r profileItem; do
+        if [[ $(echo "$profileItem" | cut -c1) = "/" ]]; then
+            # path is not relative
+            DIRArr[$index]="$profileItem"
+        else
+            # we need to append the default path to give a
+            # fully qualified path
+            DIRArr[$index]="$HOME/.mozilla/firefox-esr/$profileItem"
+        fi
+        (( index=index+1 ))
+    done < <(grep '^[Pp]ath=' "$HOME"/.mozilla/firefox-esr/profiles.ini | sed 's/[Pp]ath=//')
+fi
+
+check_suffix=1
+

--- a/common/psd.conf
+++ b/common/psd.conf
@@ -27,6 +27,7 @@
 #  epiphany
 #  falkon
 #  firefox
+#  firefox-esr
 #  firefox-flatpak
 #  firefox-flatpak-cache
 #  firefox-trunk


### PR DESCRIPTION
ticket: #334

added full support for firefox ESR, along with support for both legacy "$HOME/.mozilla/firefox-esr" and newer "$XDG_CONFIG_HOME/mozilla/firefox-esr" dirs.


P.S the solution of manually copying the profile detector files from contrib (#240) on every computer is not plausible. ESR is used in corporate environments with hundreds or thousands of computers. its the "stable Stable" edition of firefox.

I will be maintaning ESR support, since its a crucial daily driver.